### PR TITLE
WIP Section Templates

### DIFF
--- a/plugin/src/components/InsertSection/InsertSection.ts
+++ b/plugin/src/components/InsertSection/InsertSection.ts
@@ -10,8 +10,62 @@ export default editor => {
   editor.ui.registry.addButton('oc-section', {
     text: 'Insert Section',
     onAction: () => {
-      editor.settings.ordercloud.open_section_picker(editor);
+      editor.settings.ordercloud
+        .open_section_picker({ remoteCss: editor.settings.content_css[0] })
+        .then(html => {
+          editor.insertContent(
+            `<div ${OC_TINYMCE_WIDGET_ATTRIBUTE}=${OC_TINYMCE_SECTION_WIDGET_ID}>
+            ${html}
+          </div>`
+          );
+        })
+        .catch(ex => {
+          if (ex === 'Cross click') {
+            return;
+          }
+        });
     }
+  });
+
+  editor.ui.registry.addButton('oc-section-dates', {
+    text: 'Date Settings',
+    onAction: () => {
+      const startDateAttribute = 'data-oc-start-date';
+      const endDateAttribute = 'data-oc-end-date';
+      let node = editor.selection.getNode();
+      if (!isWidgetType(editor, node, OC_TINYMCE_SECTION_WIDGET_ID)) {
+        node = editor.dom.getParent(
+          node,
+          `[${OC_TINYMCE_WIDGET_ATTRIBUTE}=${OC_TINYMCE_SECTION_WIDGET_ID}]`
+        );
+      }
+      const startDate = editor.dom.getAttrib(node, startDateAttribute);
+      const endDate = editor.dom.getAttrib(node, endDateAttribute);
+      editor.settings.ordercloud
+        .open_section_date_settings({
+          startDate,
+          endDate
+        })
+        .then((updated: any) => {
+          editor.dom.setAttribs(node, {
+            [startDateAttribute]: updated.startDate,
+            [endDateAttribute]: updated.endDate
+          });
+          editor.execCommand('mceSelectNode', false, node);
+        })
+        .catch(ex => {
+          if (ex === 'Cross click') {
+            return;
+          }
+        });
+    }
+  });
+
+  editor.ui.registry.addContextToolbar('oc-section', {
+    predicate: node => isWidgetType(editor, node, OC_TINYMCE_SECTION_WIDGET_ID),
+    items: 'oc-section-dates',
+    position: 'node',
+    scope: 'node'
   });
 
   editor.on('preInit', function() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'app-root',
@@ -7,7 +6,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  constructor(private modalService: NgbModal) {}
+  constructor() {}
   title = 'marketplace-cms-components';
   buyerSiteUrl = 'https://mgr-buyer-test.ordercloud-qa.com';
   editorOptions = {
@@ -17,8 +16,8 @@ export class AppComponent {
         'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c3IiOiJjcmhpc3RpYW5zdXBwbGllcjQxMTA2IiwiY2lkIjoiN2UwZmQ2MmItOWRkOS00OTM5LTllMGItMjZkODgyZmMzNTA4IiwiaW1wIjoiMTE3NyIsInUiOiIxODEyNjMwIiwidXNydHlwZSI6InN1cHBsaWVyIiwicm9sZSI6WyJCdXllclJlYWRlciIsIk1lQWRtaW4iLCJPcmRlckFkbWluIiwiUGFzc3dvcmRSZXNldCIsIlByaWNlU2NoZWR1bGVBZG1pbiIsIlByaWNlU2NoZWR1bGVSZWFkZXIiLCJQcm9kdWN0QWRtaW4iLCJQcm9kdWN0UmVhZGVyIiwiUHJvbW90aW9uQWRtaW4iLCJQcm9tb3Rpb25SZWFkZXIiLCJTaGlwbWVudEFkbWluIiwiU3VwcGxpZXJBZGRyZXNzUmVhZGVyIiwiU3VwcGxpZXJSZWFkZXIiLCJTdXBwbGllclVzZXJSZWFkZXIiXSwiaXNzIjoiaHR0cHM6Ly9hdXRoLm9yZGVyY2xvdWQuaW8iLCJhdWQiOiJodHRwczovL2FwaS5vcmRlcmNsb3VkLmlvIiwiZXhwIjoxNTk0MTgwMzY4LCJuYmYiOjE1OTQxNTE1Njh9.VKhPjkl0xZGHctYTKoLd7Fq2QmJ5Pna-j6tqIr7GQJ0'
     },
     content_css: [
-      'https://piasstorageprod.azureedge.net/buyerweb/styles.07d24b25eb6a60350a70.css',
-      // 'https://mgrstoragetest.azureedge.net/buyerweb/styles.e94215343d3493186ae1.css',
+      // 'https://piasstorageprod.azureedge.net/buyerweb/styles.07d24b25eb6a60350a70.css',
+      'https://mgrstoragetest.azureedge.net/buyerweb/styles.e94215343d3493186ae1.css',
       'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick-theme.min.css',
       'https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.css'
     ]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SectionPickerComponent } from './components/section-picker/section-picker.component';
 import { SectionTemplateRendererComponent } from './components/section-template-renderer/section-template-renderer.component';
 import { SafeHtmlPipe } from './pipes/safe-html.pipe';
+import { SectionDateSettingsComponent } from './components/section-date-settings/section-date-settings.component';
 
 @NgModule({
   declarations: [
@@ -29,7 +30,8 @@ import { SafeHtmlPipe } from './pipes/safe-html.pipe';
     ConfirmModalComponent,
     SectionPickerComponent,
     SectionTemplateRendererComponent,
-    SafeHtmlPipe
+    SafeHtmlPipe,
+    SectionDateSettingsComponent
   ],
   imports: [
     BrowserModule,
@@ -48,7 +50,8 @@ import { SafeHtmlPipe } from './pipes/safe-html.pipe';
     ConfirmModalComponent,
     AssetPickerComponent,
     CarouselEditorComponent,
-    SectionPickerComponent
+    SectionPickerComponent,
+    SectionDateSettingsComponent
   ],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/app/components/html-editor/html-editor.component.scss
+++ b/src/app/components/html-editor/html-editor.component.scss
@@ -1,1 +1,7 @@
+.oc-tinymce-modal_backdrop {
+  z-index: 1350 !important;
+}
 
+.oc-tinymce-modal_window {
+  z-index: 1351 !important;
+}

--- a/src/app/components/html-editor/html-editor.component.ts
+++ b/src/app/components/html-editor/html-editor.component.ts
@@ -8,6 +8,7 @@ import {
   OC_TINYMCE_WIDGET_ATTRIBUTE,
   OC_TINYMCE_SECTION_WIDGET_ID
 } from 'plugin/src/constants/widget.constants';
+import { SectionDateSettingsComponent } from '../section-date-settings/section-date-settings.component';
 import { MarketplaceSDK, Asset } from 'marketplace-javascript-sdk';
 import * as MarketplaceSdkInstance from 'marketplace-javascript-sdk';
 
@@ -74,7 +75,8 @@ export class HtmlEditorComponent implements OnInit {
       'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
     imagetools_toolbar:
       'rotateleft rotateright | flipv fliph | editimage imageoptions',
-    contextmenu: 'link image imagetools table oc-product oc-row oc-col',
+    contextmenu:
+      'link image imagetools table oc-product oc-row oc-col oc-section',
     toolbar_sticky: true,
     autosave_ask_before_unload: true,
     autosave_interval: '30s',
@@ -125,11 +127,15 @@ export class HtmlEditorComponent implements OnInit {
       baseApiUrl: this.resolvedEditorOptions.ordercloud.marketplaceUrl
     });
 
-    this.resolvedEditorOptions.file_picker_callback = (callback, value, meta) => {
+    this.resolvedEditorOptions.file_picker_callback = (
+      callback,
+      value,
+      meta
+    ) => {
       this.zone.run(() => {
-        this.openAssetPicker.bind(this)(callback, value, meta)
-      })
-    }
+        this.openAssetPicker.bind(this)(callback, value, meta);
+      });
+    };
     this.resolvedEditorOptions.ordercloud.open_carousel_editor = editor => {
       this.zone.run(() => {
         // we need to manually trigger change detection
@@ -137,9 +143,14 @@ export class HtmlEditorComponent implements OnInit {
         this.openCarouselEditor.bind(this)(editor);
       });
     };
-    this.resolvedEditorOptions.ordercloud.open_section_picker = editor => {
-      this.zone.run(() => {
-        this.openSectionPicker.bind(this)(editor);
+    this.resolvedEditorOptions.ordercloud.open_section_picker = data => {
+      return this.zone.run(() => {
+        return this.openSectionPicker.bind(this)(data);
+      });
+    };
+    this.resolvedEditorOptions.ordercloud.open_section_date_settings = data => {
+      return this.zone.run(() => {
+        return this.openSectionDateSettings.bind(this)(data);
       });
     };
   }
@@ -147,16 +158,16 @@ export class HtmlEditorComponent implements OnInit {
   openAssetPicker(callback, value, meta) {
     const modalRef = this.modalService.open(AssetPickerComponent);
     modalRef.result.then((asset: Asset) => {
-      if(meta.filetype === 'image') {
-        callback(asset.Url, asset.Title)
-      } else if(meta.filetype === 'file') {
+      if (meta.filetype === 'image') {
+        callback(asset.Url, asset.Title);
+      } else if (meta.filetype === 'file') {
         // TODO: do
-        console.error('Filetype is not yet implemented')
-      } else if(meta.filetype === 'media') {
+        console.error('Filetype is not yet implemented');
+      } else if (meta.filetype === 'media') {
         // TODO: do
-        console.error('Filetype is not yet implemented')
+        console.error('Filetype is not yet implemented');
       }
-    })
+    });
   }
 
   openCarouselEditor(editor) {
@@ -168,23 +179,19 @@ export class HtmlEditorComponent implements OnInit {
     });
   }
 
-  openSectionPicker(editor) {
+  openSectionPicker(data) {
     const modalRef = this.modalService.open(SectionPickerComponent, {
       size: 'xl'
     });
-    modalRef.result
-      .then(html => {
-        editor.insertContent(
-          `<div ${OC_TINYMCE_WIDGET_ATTRIBUTE}=${OC_TINYMCE_SECTION_WIDGET_ID}>
-          ${html}
-        </div>`
-        );
-      })
-      .catch(ex => {
-        if (ex === 'Cross click') {
-          return;
-        }
-      });
-    modalRef.componentInstance.remoteCss = editor.settings.content_css[0];
+    modalRef.componentInstance.data = data;
+    return modalRef.result;
+  }
+
+  openSectionDateSettings(data) {
+    const modalRef = this.modalService.open(SectionDateSettingsComponent, {
+      size: 'md'
+    });
+    modalRef.componentInstance.data = data;
+    return modalRef.result;
   }
 }

--- a/src/app/components/html-editor/html-editor.component.ts
+++ b/src/app/components/html-editor/html-editor.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, Input, NgZone } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  Input,
+  NgZone,
+  ViewEncapsulation
+} from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AssetPickerComponent } from '../asset-picker/asset-picker.component';
 import { CarouselEditorComponent } from '../carousel-editor/carousel-editor.component';
@@ -15,7 +21,8 @@ import * as MarketplaceSdkInstance from 'marketplace-javascript-sdk';
 @Component({
   selector: 'cms-html-editor',
   templateUrl: './html-editor.component.html',
-  styleUrls: ['./html-editor.component.scss']
+  styleUrls: ['./html-editor.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 export class HtmlEditorComponent implements OnInit {
   @Input() renderSiteUrl: string;
@@ -172,7 +179,10 @@ export class HtmlEditorComponent implements OnInit {
 
   openCarouselEditor(editor) {
     const modalRef = this.modalService.open(CarouselEditorComponent, {
-      size: 'xl'
+      size: 'xl',
+      centered: true,
+      backdropClass: 'oc-tinymce-modal_backdrop',
+      windowClass: 'oc-tinymce-modal_window'
     });
     modalRef.result.then(html => {
       editor.insertContent(html);
@@ -181,7 +191,10 @@ export class HtmlEditorComponent implements OnInit {
 
   openSectionPicker(data) {
     const modalRef = this.modalService.open(SectionPickerComponent, {
-      size: 'xl'
+      size: 'xl',
+      centered: true,
+      backdropClass: 'oc-tinymce-modal_backdrop', //TODO: might wanna abstract these classes / centered as default settings for any modal that's opened from the editor
+      windowClass: 'oc-tinymce-modal_window'
     });
     modalRef.componentInstance.data = data;
     return modalRef.result;
@@ -189,7 +202,10 @@ export class HtmlEditorComponent implements OnInit {
 
   openSectionDateSettings(data) {
     const modalRef = this.modalService.open(SectionDateSettingsComponent, {
-      size: 'md'
+      size: 'md',
+      centered: true,
+      backdropClass: 'oc-tinymce-modal_backdrop',
+      windowClass: 'oc-tinymce-modal_window'
     });
     modalRef.componentInstance.data = data;
     return modalRef.result;

--- a/src/app/components/html-editor/html-editor.component.ts
+++ b/src/app/components/html-editor/html-editor.component.ts
@@ -172,13 +172,19 @@ export class HtmlEditorComponent implements OnInit {
     const modalRef = this.modalService.open(SectionPickerComponent, {
       size: 'xl'
     });
-    modalRef.result.then(html => {
-      editor.insertContent(
-        `<div ${OC_TINYMCE_WIDGET_ATTRIBUTE}=${OC_TINYMCE_SECTION_WIDGET_ID}>
+    modalRef.result
+      .then(html => {
+        editor.insertContent(
+          `<div ${OC_TINYMCE_WIDGET_ATTRIBUTE}=${OC_TINYMCE_SECTION_WIDGET_ID}>
           ${html}
         </div>`
-      );
-    });
+        );
+      })
+      .catch(ex => {
+        if (ex === 'Cross click') {
+          return;
+        }
+      });
     modalRef.componentInstance.remoteCss = editor.settings.content_css[0];
   }
 }

--- a/src/app/components/page-editor/page-editor.component.ts
+++ b/src/app/components/page-editor/page-editor.component.ts
@@ -7,14 +7,7 @@ const EMPTY_PAGE_CONTENT_DOC: Partial<PageContentDoc> = {
   Url: '',
   Description: '',
   HeaderEmbeds: '',
-  Content: `<div data-oc-widget="oc-section">
-  <div class="jumbotron border-0">
-  <div class="container text-center">
-  <h1>Lorem ipsum dolor</h1>
-  <p>Donec fermentum magna at ex pulvinar, sit amet viverra ex suscipit. Integer fringilla mauris vitae eleifend dictum.</p>
-  <a class="btn btn-primary" href="#">Start Now</a> <a class="btn btn-link" href="#">Read More</a></div>
-  </div>
-  </div>`,
+  Content: ``,
   FooterEmbeds: '',
   Active: false,
   NavigationTitle: ''

--- a/src/app/components/page-editor/page-editor.component.ts
+++ b/src/app/components/page-editor/page-editor.component.ts
@@ -7,7 +7,14 @@ const EMPTY_PAGE_CONTENT_DOC: Partial<PageContentDoc> = {
   Url: '',
   Description: '',
   HeaderEmbeds: '',
-  Content: ``,
+  Content: `<div data-oc-widget="oc-section">
+  <div class="jumbotron border-0">
+  <div class="container text-center">
+  <h1>Lorem ipsum dolor</h1>
+  <p>Donec fermentum magna at ex pulvinar, sit amet viverra ex suscipit. Integer fringilla mauris vitae eleifend dictum.</p>
+  <a class="btn btn-primary" href="#">Start Now</a> <a class="btn btn-link" href="#">Read More</a></div>
+  </div>
+  </div>`,
   FooterEmbeds: '',
   Active: false,
   NavigationTitle: ''

--- a/src/app/components/section-date-settings/section-date-settings.component.html
+++ b/src/app/components/section-date-settings/section-date-settings.component.html
@@ -1,0 +1,52 @@
+<div class="modal-header">
+  <h4 class="modal-title">Date Settings</h4>
+  <button
+    type="button"
+    class="close"
+    aria-label="Close"
+    (click)="modal.dismiss('Cross click')"
+  >
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label for="startDate">Show Date</label>
+        <input
+          id="startDate"
+          type="date"
+          class="form-control"
+          [(ngModel)]="startDate"
+          aria-describedby="startDateHelp"
+        />
+        <small id="startDateHelp" class="form-text text-muted">
+          This section will not appear until this date. If left blank, the
+          section will be visible by default.
+        </small>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-group">
+        <label for="endDate">Hide Date</label>
+        <input
+          id="endDate"
+          type="date"
+          class="form-control"
+          [(ngModel)]="endDate"
+          aria-describedby="endDateHelp"
+        />
+        <small id="endDateHelp" class="form-text text-muted">
+          This section will hide starting on this date. If left blank, the
+          section will remain visible by default.
+        </small>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-primary" (click)="submit()">
+    Save Changes
+  </button>
+</div>

--- a/src/app/components/section-date-settings/section-date-settings.component.spec.ts
+++ b/src/app/components/section-date-settings/section-date-settings.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SectionDateSettingsComponent } from './section-date-settings.component';
+
+describe('SectionDateSettingsComponent', () => {
+  let component: SectionDateSettingsComponent;
+  let fixture: ComponentFixture<SectionDateSettingsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SectionDateSettingsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SectionDateSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/section-date-settings/section-date-settings.component.ts
+++ b/src/app/components/section-date-settings/section-date-settings.component.ts
@@ -18,7 +18,6 @@ export class SectionDateSettingsComponent implements OnInit {
   }
 
   submit() {
-    console.log(this.startDate, this.endDate);
     this.modal.close({ startDate: this.startDate, endDate: this.endDate });
   }
 }

--- a/src/app/components/section-date-settings/section-date-settings.component.ts
+++ b/src/app/components/section-date-settings/section-date-settings.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit, NgZone, Input } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'cms-section-date-settings',
+  templateUrl: './section-date-settings.component.html',
+  styleUrls: ['./section-date-settings.component.scss']
+})
+export class SectionDateSettingsComponent implements OnInit {
+  @Input() data: any;
+  startDate: string;
+  endDate: string;
+  constructor(public modal: NgbActiveModal, public zone: NgZone) {}
+
+  ngOnInit(): void {
+    this.startDate = this.data.startDate;
+    this.endDate = this.data.endDate;
+  }
+
+  submit() {
+    console.log(this.startDate, this.endDate);
+    this.modal.close({ startDate: this.startDate, endDate: this.endDate });
+  }
+}

--- a/src/app/components/section-picker/section-picker.component.html
+++ b/src/app/components/section-picker/section-picker.component.html
@@ -9,17 +9,24 @@
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
-<div class="modal-body">
-  <div #list class="section-picker_list">
-    <div *ngFor="let template of sectionTemplates; index as i">
-      <cms-section-template-renderer
-        [html]="template"
-        [selected]="i === selectedTemplateIndex"
-        (click)="handleSelectTemplate(i)"
-        [previewWidth]="previewWidth"
-        [previewTransformRatio]="previewTransformRatio"
-        [remoteCss]="remoteCss"
-      ></cms-section-template-renderer>
+<div class="modal-body py-0">
+  <div class="row">
+    <div class="col-sm-3"></div>
+    <div class="col-sm-9 section-picker_container py-3">
+      <div #list class="section-picker_list">
+        <div *ngFor="let template of sectionTemplates; index as i">
+          <cms-section-template-renderer
+            [html]="template"
+            [selected]="i === selectedTemplateIndex"
+            (click)="handleSelectTemplate(i)"
+            [previewWidth]="previewWidth"
+            [previewTransformRatio]="previewTransformRatio"
+            [remoteCss]="remoteCss"
+          ></cms-section-template-renderer>
+
+          <hr *ngIf="i < sectionTemplates.length - 1" />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/components/section-picker/section-picker.component.html
+++ b/src/app/components/section-picker/section-picker.component.html
@@ -21,7 +21,7 @@
             (click)="handleSelectTemplate(i)"
             [previewWidth]="previewWidth"
             [previewTransformRatio]="previewTransformRatio"
-            [remoteCss]="remoteCss"
+            [remoteCss]="data.remoteCss"
           ></cms-section-template-renderer>
 
           <hr *ngIf="i < sectionTemplates.length - 1" />

--- a/src/app/components/section-picker/section-picker.component.scss
+++ b/src/app/components/section-picker/section-picker.component.scss
@@ -1,3 +1,7 @@
+.section-picker_container {
+  background: #f2f2f2;
+}
+
 .section-picker_list {
   width: 100%;
   overflow: hidden;

--- a/src/app/components/section-picker/section-picker.component.ts
+++ b/src/app/components/section-picker/section-picker.component.ts
@@ -17,7 +17,7 @@ import sectionPickerMock from './section-picker.mock';
 export class SectionPickerComponent implements AfterViewChecked {
   @ViewChild('list', { read: ElementRef })
   listElement: ElementRef<HTMLDivElement>;
-  @Input() remoteCss: string;
+  @Input() data: any;
   sectionTemplates = sectionPickerMock;
   selectedTemplateIndex: number;
   previewWidth: number = 1024;

--- a/src/app/components/section-template-renderer/section-template-renderer.component.html
+++ b/src/app/components/section-template-renderer/section-template-renderer.component.html
@@ -1,7 +1,7 @@
 <div
   #root
   class="section-template-renderer_root"
-  [ngClass]="{ selected: selected }"
+  [ngClass]="{ selected: selected, loading: !rootHeight }"
   [ngStyle]="{ 'height.px': rootHeight }"
 >
   <iframe

--- a/src/app/components/section-template-renderer/section-template-renderer.component.scss
+++ b/src/app/components/section-template-renderer/section-template-renderer.component.scss
@@ -5,10 +5,25 @@
 }
 
 .section-template-renderer_root {
-  border: 2px solid transparent;
-  border-radius: 4px;
+  border: 2px solid rgb(196, 196, 196);
+  border-radius: 8px;
   overflow: hidden;
   margin-bottom: 15px;
+  cursor: pointer;
+
+  &.loading {
+    position: relative;
+  }
+
+  &.loading:after {
+    content: ' ';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background-color: rgb(196, 196, 196);
+  }
 
   &.selected {
     border-color: blue;

--- a/src/app/components/section-template-renderer/section-template-renderer.component.ts
+++ b/src/app/components/section-template-renderer/section-template-renderer.component.ts
@@ -36,6 +36,11 @@ export class SectionTemplateRendererComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    this.checkPreviewTransformRatio(changes);
+    this.checkRemoteCss(changes);
+  }
+
+  checkPreviewTransformRatio(changes: SimpleChanges) {
     if (
       (changes.previewTransformRatio &&
         changes.previewTransformRatio.currentValue !==
@@ -44,6 +49,17 @@ export class SectionTemplateRendererComponent implements OnInit, OnChanges {
         changes.height.currentValue !== changes.height.previousValue)
     ) {
       this.transform = `scale(${this.previewTransformRatio})`;
+      this.rootHeight = this.previewTransformRatio * (this.height + 4);
+    }
+  }
+
+  checkRemoteCss(changes: SimpleChanges) {
+    if (
+      changes.remoteCss &&
+      !changes.remoteCss.firstChange &&
+      changes.remoteCss.currentValue !== changes.remoteCss.previousValue
+    ) {
+      this.iframeSource = this.initIframeSource();
     }
   }
 
@@ -66,7 +82,7 @@ export class SectionTemplateRendererComponent implements OnInit, OnChanges {
     if (this.iframeElement) {
       const iframeDoc = this.iframeElement.nativeElement.contentWindow.document;
       this.height = iframeDoc.body.clientHeight;
-      this.rootHeight = this.height * this.previewTransformRatio;
+      this.rootHeight = (this.height + 4) * this.previewTransformRatio;
     }
   }
 }


### PR DESCRIPTION
### New Stuff
- Mock sections currently being used (array of html strings)
- Section picker displays these templates in the section-template-renderer (iframe)
- User selects a section template, and hits "Add Section"
- Selected section is added to the editor content
- Section context toolbar currently has 1 button for configuring data-oc-start-date, data-oc-end-date attributes

### Changes
- Fix NgbModal z-index issue for modals opened from the editor
- Alter the way the callback settings for modals work (no longer passing in the entire editor object), see `openSectionPicker` or `openSectionDateSettings` in `html-editor.component.ts` for an example.